### PR TITLE
Only rewrite if language is fallbackType: fallback

### DIFF
--- a/Classes/Middleware/DynamicLanguageMode.php
+++ b/Classes/Middleware/DynamicLanguageMode.php
@@ -28,7 +28,7 @@ class DynamicLanguageMode implements MiddlewareInterface
 
         $site = $request->getAttribute('site');
         $default = $site->getLanguages()[0];
-        if ($lang->getLanguageId() !== $default->getLanguageId()) {
+        if ($lang->getFallbackType() === 'fallback' && $lang->getLanguageId() !== $default->getLanguageId()) {
             // Check if page is in "Free mode" and apply a dynamic language configuration in that case
             $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
             $query = $queryBuilder

--- a/Classes/Middleware/DynamicLanguageMode.php
+++ b/Classes/Middleware/DynamicLanguageMode.php
@@ -45,7 +45,7 @@ class DynamicLanguageMode implements MiddlewareInterface
                 $queryPage = $queryBuilderPage
                     ->count('*')
                     ->from('pages', 'p')
-                    ->where($queryBuilder->expr()->eq('p.pid', $queryBuilderPage->createNamedParameter(intval($pageArguments->getPageId()), \PDO::PARAM_INT)))
+                    ->where($queryBuilder->expr()->eq('p.l10n_parent', $queryBuilderPage->createNamedParameter(intval($pageArguments->getPageId()), \PDO::PARAM_INT)))
                     ->andWhere($queryBuilder->expr()->eq('p.sys_language_uid', $queryBuilderPage->createNamedParameter(intval($lang->getLanguageId()), \PDO::PARAM_INT)));
                 $countPage = $queryPage->execute()->fetchColumn();
             }


### PR DESCRIPTION
Thank you. this is very helpful! I've found it via https://forge.typo3.org/issues/90261.

I suggest to only rewrite languages of `fallbackType: fallback`. There might be other language configurations (for example `strict`) where we do not want to use `fallbackType: free`. 

I've had an example where translated `sys_file_metadata` was not fetched but instead the default language was used in the frontend for that language.
