### PR TITLE
Usage in TYPO3 11.5

### DIFF
--- a/Classes/Middleware/DynamicLanguageMode.php
+++ b/Classes/Middleware/DynamicLanguageMode.php
@@ -45,7 +45,7 @@ class DynamicLanguageMode implements MiddlewareInterface
                 $queryPage = $queryBuilderPage
                     ->count('*')
                     ->from('pages', 'p')
-                    ->where($queryBuilder->expr()->eq('p.pid', $queryBuilderPage->createNamedParameter(intval($pageArguments->getPageId()), \PDO::PARAM_INT)))
+                    ->where($queryBuilder->expr()->eq('p.l10n_parent', $queryBuilderPage->createNamedParameter(intval($pageArguments->getPageId()), \PDO::PARAM_INT)))
                     ->andWhere($queryBuilder->expr()->eq('p.sys_language_uid', $queryBuilderPage->createNamedParameter(intval($lang->getLanguageId()), \PDO::PARAM_INT)));
                 $countPage = $queryPage->execute()->fetchColumn();
             }

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -16,6 +16,7 @@ return [
             'before' => [
                 /* Note: prepare-tsfe-rendering is not a Stable target and may be removed in TYPO3 v10 */
                 'typo3/cms-frontend/prepare-tsfe-rendering',
+                'typo3/cms-frontend/tsfe',
             ],
             'after' => [
                  'typo3/cms-frontend/page-argument-validator'


### PR DESCRIPTION
Nice Extension, exactly what i was looking for 👍 

Last commit introduces page translation check, but with wrong field (pid), so wanted page was only visible when parent page has a page translation in wanted language.